### PR TITLE
Fix WebSocket connection token logging

### DIFF
--- a/lib/wsServer.js
+++ b/lib/wsServer.js
@@ -11,14 +11,16 @@ wss.on('connection', (ws, req) => {
 
   console.log('[WS] New connection:', req.url);
   console.log('[WS] Secret:', process.env.NEXTAUTH_SECRET);
-  console.log('[WS] token type:', typeof token);
-  console.log('[WS] token length:', token.length);
-  console.log('[WS] Token:', token);
 
   if (!token) {
+    console.warn('[WS] Missing token');
     ws.close(1008, 'Missing token');
     return;
   }
+
+  console.log('[WS] token type:', typeof token);
+  console.log('[WS] token length:', token.length);
+  console.log('[WS] Token:', token);
 
   let payload;
   try {


### PR DESCRIPTION
## Summary
- avoid crashing on WebSocket connections when token is missing

## Testing
- `npm run lint` *(fails: Cannot serialize key "parse" in parser)*

------
https://chatgpt.com/codex/tasks/task_e_6841a02b82b88333bcf272b1f18e5738