### PR TITLE
Add JWT header tests

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,7 +1,5 @@
 import GitHubProvider from 'next-auth/providers/github';
-import jwt from 'jsonwebtoken';
-
-const JWT_SECRET = process.env.NEXTAUTH_SECRET;
+import { getSubFromAuthHeader } from './token.js';
 
 export const authOptions = {
   providers: [
@@ -39,15 +37,4 @@ export const authOptions = {
   secret: process.env.NEXTAUTH_SECRET,
 };
 
-export function getSubFromAuthHeader(authHeader) {
-  if (!authHeader?.startsWith('Bearer ')) return null;
-
-  const token = authHeader.slice(7); // remove 'Bearer '
-  try {
-    const payload = jwt.verify(token, JWT_SECRET);
-    return payload?.sub || null;
-  } catch (err) {
-    console.warn('[JWT] Invalid token:', err);
-    return null;
-  }
-}
+export { getSubFromAuthHeader };

--- a/lib/token.js
+++ b/lib/token.js
@@ -1,0 +1,15 @@
+import jwt from 'jsonwebtoken';
+
+export function getSubFromAuthHeader(authHeader) {
+  const JWT_SECRET = process.env.NEXTAUTH_SECRET;
+  if (!authHeader?.startsWith('Bearer ')) return null;
+
+  const token = authHeader.slice(7); // remove 'Bearer '
+  try {
+    const payload = jwt.verify(token, JWT_SECRET);
+    return payload?.sub || null;
+  } catch (err) {
+    console.warn('[JWT] Invalid token:', err);
+    return null;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "ws": "node server.js"
+    "ws": "node server.js",
+    "test": "node --test"
   },
   "dependencies": {
     "@apollo/server": "^4.12.1",

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import jwt from 'jsonwebtoken';
+import { getSubFromAuthHeader } from '../lib/token.js';
+
+test('returns sub for valid Bearer token', () => {
+  process.env.NEXTAUTH_SECRET = 'test-secret';
+  const token = jwt.sign({ sub: 'user123' }, process.env.NEXTAUTH_SECRET);
+  const header = `Bearer ${token}`;
+  const sub = getSubFromAuthHeader(header);
+  assert.equal(sub, 'user123');
+});
+
+test('returns null for invalid or missing header', () => {
+  process.env.NEXTAUTH_SECRET = 'test-secret';
+  let result = getSubFromAuthHeader('Bearer invalidtoken');
+  assert.equal(result, null);
+
+  result = getSubFromAuthHeader(undefined);
+  assert.equal(result, null);
+});


### PR DESCRIPTION
## Summary
- introduce `getSubFromAuthHeader` helper in `lib/token.js`
- re-export helper from `lib/auth.js`
- add tests for JWT header parsing
- add `npm test` script using Node test runner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841a691cb4c8333b11b853f22f2464f